### PR TITLE
home page: move email list up

### DIFF
--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -5,6 +5,36 @@
         <b><span class="logo-h">h</span>ackEDU</b> empowers high school students <b>to build things they
         care about</b> through <b>creating</b>, <b>connecting</b>, and growing
         <b>student-run</b> coding clubs in <b>high schools</b>.
+.email-form.small-section
+  .row
+    %h1 Stay in the loop
+    .small-11.medium-6.small-centered.columns
+      / MailChimp Signup Form
+      #mc_embed_signup
+      %form#mc-embedded-subscribe-form.validate{action: "//hackedu.us10.list-manage.com/subscribe/post?u=738aabcd5284a4d3df761a981&id=4c8d1b3833",
+                                                method: "post",
+                                                  name: "mc-embedded-subscribe-form",
+                                            novalidate: "",
+                                                target: "_blank"}
+        #mc_embed_signup_scroll
+          .mc-field-group
+            %input#mce-EMAIL.required.email{name: "EMAIL",
+                                            type: "email",
+                                           value: "",
+                                     placeholder: "zaphod@beeblebrox.com"}
+          #mce-responses.clear
+            #mce-error-response.response{style: "display: none"}
+            #mce-success-response.response{style: "display: none"}
+          / real people should not fill this in and expect good things - do not remove this or risk form bot signups
+          %div{style: "position: absolute; left: -5000px;"}
+            %input{name: "b_738aabcd5284a4d3df761a981_4c8d1b3833",
+               tabindex: "-1",
+                   type: "text",
+                  value: ""}
+          .clear
+            %input#mc-embedded-subscribe.button{name: "subscribe",
+                                                type: "submit",
+                                               value: "Subscribe"}
 .description.small-section
   .row
     .small-11.small-centered.columns
@@ -37,46 +67,6 @@
         .small-12.medium-6.columns
           = link_to 'Start a Hack Club', apply_path, class: 'button outline-outward'
 #home-map-jumbotron
-.main-section.sponsors
-  %h1 Sponsors
-  .row.logos
-    %ul.small-block-grid-1.medium-block-grid-2
-      %li= image_tag 'sponsors/codehs.png', alt: 'CodeHS'
-      %li= image_tag 'sponsors/hackreactor.png', alt: 'Hack Reactor'
-      %li= image_tag 'sponsors/workflowy.png', alt: 'Workflowy'
-      %li= image_tag 'sponsors/makeschool.svg', alt: 'Make School'
-      %li= image_tag 'sponsors/nitrousio.svg', alt: 'Nitrous.IO'
-      %li= image_tag 'sponsors/rackspace.svg', alt: 'Rackspace'
-.email-form.small-section
-  .row
-    %h1 Stay in the loop
-    .small-11.medium-6.small-centered.columns
-      / MailChimp Signup Form
-      #mc_embed_signup
-      %form#mc-embedded-subscribe-form.validate{action: "//hackedu.us10.list-manage.com/subscribe/post?u=738aabcd5284a4d3df761a981&id=4c8d1b3833",
-                                                method: "post",
-                                                  name: "mc-embedded-subscribe-form",
-                                            novalidate: "",
-                                                target: "_blank"}
-        #mc_embed_signup_scroll
-          .mc-field-group
-            %input#mce-EMAIL.required.email{name: "EMAIL",
-                                            type: "email",
-                                           value: "",
-                                     placeholder: "zaphod@beeblebrox.com"}
-          #mce-responses.clear
-            #mce-error-response.response{style: "display: none"}
-            #mce-success-response.response{style: "display: none"}
-          / real people should not fill this in and expect good things - do not remove this or risk form bot signups
-          %div{style: "position: absolute; left: -5000px;"}
-            %input{name: "b_738aabcd5284a4d3df761a981_4c8d1b3833",
-               tabindex: "-1",
-                   type: "text",
-                  value: ""}
-          .clear
-            %input#mc-embedded-subscribe.button{name: "subscribe",
-                                                type: "submit",
-                                               value: "Subscribe"}
 .rackspace
   .row
     %p


### PR DESCRIPTION
This moves the email list further up on the page:
![screenshot 2015-04-07 at 11 04 07 pm](https://cloud.githubusercontent.com/assets/5891442/7039710/70c68f28-dd7a-11e4-98db-11b9d0032c41.png)
