### PR TITLE
Set up CircleCI to test for broken markdown links.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+dependencies:
+  pre:
+    - sudo curl -L -o /usr/local/bin/check_markdown_links https://git.io/v3aCL; sudo chmod +x /usr/local/bin/check_markdown_links
+
+test:
+  override:
+    - check_markdown_links


### PR DESCRIPTION
This PR configures CircleCI to test for broken markdown links using https://github.com/hackedu/hack-camp/blob/master/meta/bin/check_markdown_links. I figure that for now we can link to that script directly, though I'm sure we'll eventually want to move it to a more centralized location so it'll be more intuitive to use it across repos.