### PR TITLE
Add section to README on labs program setup.

### DIFF
--- a/meta/labs_program/README.md
+++ b/meta/labs_program/README.md
@@ -3,6 +3,22 @@
 This document will contain a brief overview of our labs program and what it'll
 entail going into the 2015 fall semester.
 
+## Setup
+
+We're currently in the midst of setting up our labs program. Here's our
+checklist for getting everything going:
+
+- [ ] Select everyone we're going to interview (_Deadline: 08.17.15_,
+  [#30](https://github.com/hackedu/hackedu/issues/30)).
+  - We're keeping track of people in the private sheet
+    https://docs.google.com/spreadsheets/d/1Q6E36NK7N_mKp_LJwMW-P3KUZXPsHQTJWyoyKvrneuc.
+- [ ] Schedule all interviews (_Deadline: 08.20.15_,
+  [#54](https://github.com/hackedu/hackedu/issues/31))
+- [ ] Send out all acceptances and rejections (_Deadline: 08.25.15_,
+  [#48](https://github.com/hackedu/hackedu/issues/48))
+- [ ] All acceptance contracts signed (_Deadline: 08.28.15_,
+  [#55](https://github.com/hackedu/hackedu/issues/55))
+
 ## Meetings
 
 All meetings related to the labs program should be put into the `meetings`


### PR DESCRIPTION
This PR adds a section to the README of the labs program on what we're going through to set up the program right now.

This also gives us a place to put deliverables for tasks that may have the private result in Google Docs (we can just check off the box).

@MaxWofford can you review/merge this?