### PR TITLE
Clarify that users should work on workshops independently

### DIFF
--- a/playbook/workshops/README.md
+++ b/playbook/workshops/README.md
@@ -11,6 +11,9 @@ Our workshops aim to:
 - work well when done in pairs or individually.
 - be tinkerable.
 
+We recommend workshops links be provided to students, with each student working
+on the workshops independently and receiving support when needed.
+
 Each workshop is a markdown file and has associated facilitation guidelines.
 
 See our general workshop facilitation guidelines


### PR DESCRIPTION
This was originally unclear to me, but it makes a lot of sense when it is clarified. Having people listening a single person present a workshop is difficult and not manageable with many people.