### PR TITLE
Remove trailing Twilio API host slash

### DIFF
--- a/workshops/lib/twilio-basic/src/js/browserified_twilio.js
+++ b/workshops/lib/twilio-basic/src/js/browserified_twilio.js
@@ -1,5 +1,5 @@
 // Overides the default API host used if set.
-var overrideHost = 'surrogate.hackedu.us/api.twilio.com/';
+var overrideHost = 'surrogate.hackedu.us/api.twilio.com';
 
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 


### PR DESCRIPTION
Currently Twilio API request paths look like:

    surrogate.hackedu.us/api.twilio.com//2010-04-01/Accounts/...

This change makes the request path look like the following, removing the
extra slash.

    surrogate.hackedu.us/api.twilio.com/2010-04-01/Accounts/...