### PR TITLE
Link to Cloud9 from Ajar

### DIFF
--- a/workshops/contrib/ajar/README.md
+++ b/workshops/contrib/ajar/README.md
@@ -46,6 +46,9 @@ Check out the demo [here](http://jsbin.com/jizoyo/edit?output)
 
 ### Creating the files
 
+If you haven't already set up Cloud9, [click here](../cloud9/README.md) to be
+taken to a guide on setting it up. Once you've done that, continue over here.
+
 In Cloud9, create two files in a folder of your choice:
 
 - index.html


### PR DESCRIPTION
During CodeDay Bay Area I had some hackers go through the Ajar workshop to get started. All of them got lost because they didn't know what Cloud9 was and hadn't set it up yet. This change links to the Cloud9 setup guide from the Ajar workshop to prevent this in the future.