### PR TITLE
Link to workshops/README.md in main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center"><img src="https://raw.githubusercontent.com/hackedu/meta/5243af92814b6daacadd66e1342ad073e023544c/logos/hackedu_letter_opaque.png" alt="hackEDU"/></p>
 <p align="center">
-<b><a href="workshops/">workshops</a></b>
+<b><a href="workshops/README.md">workshops</a></b>
 |
 <b><a href="case_studies/">case studies</a></b>
 |
@@ -33,7 +33,7 @@ check out and contribute to this repository.
 
 Important links:
 
-- [Workshops](workshops/) :: Workshops for use in clubs
+- [Workshops](workshops/README.md) :: Workshops for use in clubs
 - https://slack.hackedu.us :: Link to join our Slack community
 
 ## Questions? Comments? Concerns?


### PR DESCRIPTION
When you're linked to `workshops/` on a small screen, the directory listing fills up most of the screen, making it difficult to see what our workshops are to a beginner.

This changes the workshop links from `workshops/` to `workshops/README.md` to make our list of workshops more understandable on smaller screens.